### PR TITLE
let core reject the unsupported coalescing parameters

### DIFF
--- a/r8152.c
+++ b/r8152.c
@@ -17134,6 +17134,9 @@ static int rtl8152_set_ringparam(struct net_device *netdev,
 }
 
 static const struct ethtool_ops ops = {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0)
+        .supported_coalesce_params = ETHTOOL_COALESCE_USECS,
+#endif
 	.get_drvinfo = rtl8152_get_drvinfo,
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,20,0)
 	.get_settings = rtl8152_get_settings,


### PR DESCRIPTION
Set ethtool_ops->supported_coalesce_params to let the core reject unsupported coalescing parameters.

Required for Linux 5.7 support; otherwise, driver initialization will fail with 'couldn't register device' (errno 22).

See https://aur.archlinux.org/packages/r8152-dkms