### PR TITLE
Use strncpy for older kernels

### DIFF
--- a/50-usb-realtek-net.rules
+++ b/50-usb-realtek-net.rules
@@ -43,4 +43,7 @@ ATTR{idVendor}=="0955", ATTR{idProduct}=="09ff", ATTR{bConfigurationValue}!="$en
 # LINKSYS
 ATTR{idVendor}=="13b1", ATTR{idProduct}=="0041", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
 
+# ASUS
+ATTR{idVendor}=="0b05", ATTR{idProduct}=="1976", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+
 LABEL="usb_realtek_net_end"

--- a/r8152.c
+++ b/r8152.c
@@ -18626,8 +18626,13 @@ static void rtl8152_get_drvinfo(struct net_device *netdev,
 {
 	struct r8152 *tp = netdev_priv(netdev);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,3,0)
+	strncpy(info->driver, MODULENAME, sizeof(info->driver));
+	strncpy(info->version, DRIVER_VERSION, sizeof(info->version));
+#else
 	strscpy(info->driver, MODULENAME, sizeof(info->driver));
 	strscpy(info->version, DRIVER_VERSION, sizeof(info->version));
+#endif
 	usb_make_path(tp->udev, info->bus_info, sizeof(info->bus_info));
 }
 


### PR DESCRIPTION
Support for compilation on older linux kernels without support for strscpy