### PR TITLE
Fixed build on kernels 6.8+

### DIFF
--- a/r8152.c
+++ b/r8152.c
@@ -19690,7 +19690,7 @@ static int rtltool_ioctl(struct r8152 *tp, struct ifreq *ifr)
 		uinfo->idVendor = __le16_to_cpu(udev->descriptor.idVendor);
 		uinfo->idProduct = __le16_to_cpu(udev->descriptor.idProduct);
 		uinfo->bcdDevice = __le16_to_cpu(udev->descriptor.bcdDevice);
-		strlcpy(uinfo->devpath, udev->devpath, sizeof(udev->devpath));
+		strscpy(uinfo->devpath, udev->devpath, sizeof(udev->devpath));
 		pla_ocp_read(tp, PLA_IDR, sizeof(uinfo->dev_addr),
 			     uinfo->dev_addr);
 


### PR DESCRIPTION
strlcpy was removed in 6.8  . strncpy is a 1:1 replacement if return code is not used.