### PR TITLE
updates to prevent cpu stall when CONFIG_PREEMPT is set

### DIFF
--- a/r8152.c
+++ b/r8152.c
@@ -814,7 +814,7 @@ enum rtl_register_content {
 #define mtu_to_size(m)		((m) + VLAN_ETH_HLEN + ETH_FCS_LEN)
 #define size_to_mtu(s)		((s) - VLAN_ETH_HLEN - ETH_FCS_LEN)
 
-#define RTL_MAX_SG_NUM		16
+#define RTL_MAX_SG_NUM		32	// Ensure RTL_MAX_SG_NUM is large enough to enqueue fragmenented packet to prevent CPU stall
 
 /* rtl8152 flags */
 enum rtl8152_flags {
@@ -3018,6 +3018,8 @@ static int r8152_tx_agg_fill(struct r8152 *tp, struct tx_agg *agg)
 	struct net_device *netdev = tp->netdev;
 	int remain, ret;
 	u8 *tx_data;
+	int processed_in_loop = 0;
+	const int max_processed_in_loop = 8;
 
 	__skb_queue_head_init(&skb_head);
 	spin_lock(&tx_queue->lock);
@@ -3079,6 +3081,13 @@ static int r8152_tx_agg_fill(struct r8152 *tp, struct tx_agg *agg)
 
 		remain = agg_buf_sz -
 			 (int)(tx_agg_align(tp, tx_data) - agg->head);
+
+		processed_in_loop++;
+		if (processed_in_loop >= max_processed_in_loop)
+		{
+			cond_resched();
+			processed_in_loop = 0;
+		}
 	}
 
 	if (!skb_queue_empty(&skb_head)) {
@@ -3124,6 +3133,8 @@ static int r8152_tx_agg_sg_fill(struct r8152 *tp, struct tx_agg *agg)
 	int max_sg_num, ret, sg_num;
 	struct scatterlist *sg;
 	int padding = 0;
+	int processed_in_loop = 0;
+	const int max_processed_in_loop = 8;
 
 	__skb_queue_head_init(&skb_head);
 	spin_lock(&tx_queue->lock);
@@ -3211,6 +3222,13 @@ static int r8152_tx_agg_sg_fill(struct r8152 *tp, struct tx_agg *agg)
 
 		padding = len + tp->tx_desc.size;
 		padding = ALIGN(padding, tp->tx_desc.align) - padding;
+
+		processed_in_loop++;
+		if (processed_in_loop >= max_processed_in_loop)
+		{
+			cond_resched();
+			processed_in_loop = 0;
+		}
 	}
 
 	if (!skb_queue_empty(&skb_head)) {
@@ -3592,45 +3610,109 @@ out1:
 	return work_done;
 }
 
+
+
 static void tx_bottom(struct r8152 *tp)
 {
-	int res;
+	int res = 0; // Initialize res to ensure loop condition is well-defined at start
+	unsigned int iteration_count = 0;
+	// Budgeting based on iterations to prevent endless loops on unprocessable SKBs
+	// If an SKB is unprocessable, the fill function will likely return res=0 & agg->skb_num=0.
+	// We want to limit how many times we try this before yielding.
+	const unsigned int max_iterations_per_tasklet_run = 8;
+
+	// netif_info(tp, tx_queued, tp->netdev, "tx_bottom ENTER, tx_queue_len=%u\n", skb_queue_len(&tp->tx_queue)); // DEBUG
 
 	do {
 		struct net_device *netdev = tp->netdev;
 		struct tx_agg *agg;
 
-		if (skb_queue_empty(&tp->tx_queue))
+		if (skb_queue_empty(&tp->tx_queue)) {
+			// netif_info(tp, tx_queued, netdev, "tx_bottom: tx_queue empty, breaking.\n"); // DEBUG
 			break;
+		}
+
+		if (iteration_count >= max_iterations_per_tasklet_run) {
+			// netif_info(tp, tx_queued, netdev, "tx_bottom: Max iterations (%u) hit, rescheduling.\n", max_iterations_per_tasklet_run); // DEBUG
+			if (!skb_queue_empty(&tp->tx_queue))
+				tasklet_schedule(&tp->tx_tl);
+			break;
+		}
+		iteration_count++;
 
 		agg = r8152_get_tx_agg(tp);
-		if (!agg)
+		if (!agg) {
+			// netif_info(tp, tx_queued, netdev, "tx_bottom: No free agg blocks, stopping queue.\n"); // DEBUG
+			// Only stop queue if it was running and we intended to send but couldn't get an agg.
+			// If queue is already stopped, or if it's empty, no need to stop again.
+			if (netif_running(netdev) && !netif_queue_stopped(netdev)) {
+				netif_stop_queue(netdev);
+			}
 			break;
-
-		if (tp->sg_use)
-			res = r8152_tx_agg_sg_fill(tp, agg);
-		else
-			res = r8152_tx_agg_fill(tp, agg);
-
-		if (!res)
-			continue;
-
-		if (res == -ENODEV) {
-			rtl_set_unplug(tp);
-			netif_device_detach(netdev);
-		} else {
-			struct net_device_stats *stats = &netdev->stats;
-			unsigned long flags;
-
-			netif_warn(tp, tx_err, netdev,
-				   "failed tx_urb %d\n", res);
-			stats->tx_dropped += agg->skb_num;
-
-			spin_lock_irqsave(&tp->tx_lock, flags);
-			list_add_tail(&agg->list, &tp->tx_free);
-			spin_unlock_irqrestore(&tp->tx_lock, flags);
 		}
-	} while (res == 0);
+
+		// Reset agg fields for this new attempt
+		agg->skb_num = 0;
+		agg->skb_len = 0;
+		agg->skb_bytes = 0;
+
+		if (tp->sg_use) {
+			// netif_info(tp, tx_queued, netdev, "tx_bottom: Calling r8152_tx_agg_sg_fill for iteration %u\n", iteration_count); // DEBUG
+			// For SG, tx_skb queue needs to be empty before fill
+			WARN_ON_ONCE(!skb_queue_empty(&agg->tx_skb));
+			res = r8152_tx_agg_sg_fill(tp, agg);
+		} else {
+			// netif_info(tp, tx_queued, netdev, "tx_bottom: Calling r8152_tx_agg_fill for iteration %u\n", iteration_count); // DEBUG
+			res = r8152_tx_agg_fill(tp, agg);
+		}
+		// netif_info(tp, tx_queued, netdev, "tx_bottom loop iter %u: res=%d, agg->skb_num=%u\n", iteration_count, res, agg->skb_num); // DEBUG
+
+		if (res == 0) { // URB submission likely OK OR agg was empty (no SKBs processed by fill)
+			if (agg->skb_num > 0) {
+				// Successfully processed an aggregation with data, reset iteration_count
+				// to allow full budget for next set of packets if tx_queue is not empty.
+				iteration_count = 0; // Reset if progress was made
+			} else {
+				// Fill function returned 0, but agg->skb_num is 0.
+				// This means an agg block was acquired, but fill func couldn't put SKBs in it
+				// (e.g., head of tx_queue was unprocessable or tx_queue became empty before splice).
+				// The agg block should have been returned to tx_free by the fill function in this case.
+				// So, r8152_get_tx_agg in the next iteration should still work if tx_free is not empty.
+				// netif_info(tp, tx_queued, netdev, "tx_bottom: iter %u, res=0 but agg->skb_num=0. Continuing.\n", iteration_count); // DEBUG
+			}
+			continue;
+		}
+
+		/* res < 0 means error from usb_submit_urb or similar */
+		/* The agg block was not submitted or failed submission. It should be returned to tx_free. */
+		/* Note: r8152_tx_agg_fill/sg_fill already handle returning agg on their internal errors before URB submission, */
+		/* or if sg_num == 0 for sg_fill. This path is mainly for usb_submit_urb failure. */
+		if (res < 0) { // Explicitly check for res < 0 for error handling
+			struct net_device_stats *stats = &netdev->stats;
+			unsigned long flags_err;
+
+			netif_warn(tp, tx_err, netdev, "failed tx_urb %d in iter %u\n", res, iteration_count);
+
+			// Ensure stats->tx_dropped is only incremented if agg->skb_num was > 0
+			// (i.e., if SKBs were actually prepared for this agg before submission failed).
+			// However, skb_num would reflect what *would have been sent*.
+			if (agg->skb_num > 0) {
+				stats->tx_dropped += agg->skb_num;
+				// If SG was used, clear the skb list in agg
+				if (tp->sg_use) {
+					while (!skb_queue_empty(&agg->tx_skb))
+					dev_kfree_skb_any(__skb_dequeue(&agg->tx_skb));
+				}
+			}
+			// Return the agg block to the free list
+			spin_lock_irqsave(&tp->tx_lock, flags_err);
+			list_add_tail(&agg->list, &tp->tx_free);
+			spin_unlock_irqrestore(&tp->tx_lock, flags_err);
+			// Loop will terminate due to res != 0
+		}
+	} while (res == 0); // Loop continues if res=0 (submission OK or empty agg handled) AND budget not hit.
+
+	// netif_info(tp, tx_queued, tp->netdev, "tx_bottom EXIT, tx_queue_len=%u, total_loops=%u\n", skb_queue_len(&tp->tx_queue), iteration_count); // DEBUG
 }
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,9,0)


### PR DESCRIPTION
tested successfully with kernel versions 5.4.0, 5.10

#define RTL_MAX_SG_NUM 16 // 16 is insufficient in the cases of highly fragmented packets which leads to a CPU stall and subsequent system hang

Setting RTL_MAX_SG_NUM to 32 alleviates the issue with CONFIG_PREEEMPT set to y

The other changes in the request are to ensure work is actually being completed on tx and to defer to other tasks when CONFIG_PREEMPT is set

Hopefully this helps others facing similar issues.

trace from CPU stall with v2.19.2:
[   67.745833] rcu: INFO: rcu_preempt self-detected stall on CPU

[   67.745844] rcu:     3-....: (1 GPs behind) idle=576/1/0x4000000000000002 softirq=11193/11194 fqs=5250 

[   67.745848]    (t=21000 jiffies g=25445 q=36795)

[   67.745851] Task dump for CPU 3:

[   67.745854] wss             R  running task        0  1072      1 0x00000002

[   67.745860] Call trace:

[   67.745870]  dump_backtrace+0x0/0x140

[   67.745874]  show_stack+0x14/0x20

[   67.745879]  sched_show_task+0x108/0x138

[   67.745883]  dump_cpu_task+0x40/0x50

[   67.745888]  rcu_dump_cpu_stacks+0x94/0xd0

[   67.745891]  rcu_sched_clock_irq+0x7bc/0xa08

[   67.745895]  update_process_times+0x2c/0x68

[   67.745900]  tick_sched_handle.isra.0+0x30/0x50

[   67.745904]  tick_sched_timer+0x48/0x98

[   67.745908]  __hrtimer_run_queues+0x110/0x1b0

[   67.745911]  hrtimer_interrupt+0xe4/0x240

[   67.745916]  arch_timer_handler_phys+0x30/0x40

[   67.745921]  handle_percpu_devid_irq+0x80/0x140

[   67.745925]  generic_handle_irq+0x24/0x38

[   67.745929]  __handle_domain_irq+0x60/0xb8

[   67.745932]  gic_handle_irq+0x5c/0xb8

[   67.745936]  el1_irq+0xb8/0x180

[   67.745941]  _raw_spin_unlock_irqrestore+0xc/0x48

[   67.745946]  tasklet_action_common.isra.0+0xcc/0x178

[   67.745950]  tasklet_action+0x24/0x30

[   67.745953]  __do_softirq+0x118/0x22c

[   67.745956]  do_softirq.part.0+0x60/0x68

[   67.745961]  __local_bh_enable_ip+0x8c/0x98

[   67.745965]  ip_finish_output2+0x17c/0x580

[   67.745969]  __ip_finish_output+0xc8/0x1f0

[   67.745972]  ip_output+0xf4/0x1a0

[   67.745975]  ip_local_out+0x44/0x58

[   67.745978]  __ip_queue_xmit+0x124/0x390

[   67.745983]  ip_queue_xmit+0x10/0x18

[   67.745986]  __tcp_transmit_skb+0x49c/0xab0

[   67.745990]  tcp_write_xmit+0x230/0x1098

[   67.745993]  __tcp_push_pending_frames+0x38/0xc8

[   67.745998]  tcp_push+0x118/0x168

[   67.746002]  tcp_sendmsg_locked+0xa54/0xb50

[   67.746006]  tcp_sendmsg+0x34/0x58

[   67.746011]  inet_sendmsg+0x40/0x68

[   67.746016]  ___sys_sendmsg+0x280/0x2c0

[   67.746019]  __sys_sendmsg+0x64/0xb8

[   67.746022]  __arm64_sys_sendmsg+0x20/0x28

[   67.746028]  el0_svc_common.constprop.0+0x68/0x160

[   67.746032]  el0_svc_handler+0x6c/0x88

[   67.746035]  el0_svc+0x8/0xc