### PR TITLE
Fix dev_set_mac_address() call for Linux 6.16+ API change

### DIFF
--- a/r8152.c
+++ b/r8152.c
@@ -35,6 +35,9 @@
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,10)
 #include <net/gso.h>
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,10) */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,16,0)
+#include <linux/socket.h>
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(6,16,0) */
 
 /* Version Information */
 #define DRIVER_SUFFIX
@@ -26240,9 +26243,12 @@ static int rtl8152_post_reset(struct usb_interface *intf)
 		rtnl_lock();
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 		dev_set_mac_address(tp->netdev, &sa);
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6,16,0)
 		dev_set_mac_address(tp->netdev, &sa, NULL);
-#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0) */
+#else /* >= 6.16: __kernel_sockaddr_storage API change */
+		dev_set_mac_address(tp->netdev,
+				    (struct __kernel_sockaddr_storage *)&sa, NULL);
+#endif
 		rtnl_unlock();
 	}
 


### PR DESCRIPTION
This PR fixes build failures with Linux kernel 6.16+ due to the dev_set_mac_address() API change.

Details

    Kernel < 5.17: dev_set_mac_address(dev, &sa)
    Kernel < 6.16: dev_set_mac_address(dev, &sa, NULL)
    Kernel ≥ 6.16: dev_set_mac_address(dev, (struct __kernel_sockaddr_storage *)&sa, NULL)

    Added #include <linux/socket.h> for the new struct definition.

Tested on

    CachyOS Linux 6.16.0-5
    Realtek RTL8157 5 GbE USB-C adapter (UGREEN)
    Link negotiates successfully at 5000 Mb/s Full Duplex