### PR TITLE
fix transmit queue timeout

### DIFF
--- a/r8152.c
+++ b/r8152.c
@@ -2437,6 +2437,8 @@ static void write_bulk_callback(struct urb *urb)
 	if (test_bit(RTL8152_UNPLUG, &tp->flags))
 		return;
 
+	netif_trans_update(netdev);
+
 	if (!skb_queue_empty_lockless(&tp->tx_queue))
 		tasklet_schedule(&tp->tx_tl);
 }
@@ -2498,6 +2500,8 @@ static void write_bulk_sg_callback(struct urb *urb)
 
 	if (test_bit(RTL8152_UNPLUG, &tp->flags))
 		return;
+
+	netif_trans_update(netdev);
 
 	if (!skb_queue_empty_lockless(&tp->tx_queue))
 		tasklet_schedule(&tp->tx_tl);


### PR DESCRIPTION
The TX queue length reached the threshold and stopped working, ultimately causing the network card to reset.

This patch will proactively refresh the netdev watchdog transmission start time (feed the dog) after each USB submission completes.