### PR TITLE
Added reporting of software timestamping capabilities

### DIFF
--- a/r8152.c
+++ b/r8152.c
@@ -30512,6 +30512,9 @@ static const struct ethtool_ops ops = {
 	.set_ringparam = rtl8152_set_ringparam,
 	.get_pauseparam = rtl8152_get_pauseparam,
 	.set_pauseparam = rtl8152_set_pauseparam,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,5,0)
+    .get_ts_info = ethtool_op_get_ts_info,
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,5,0) */
 };
 
 static int rtltool_ioctl(struct r8152 *tp, struct ifreq *ifr)


### PR DESCRIPTION
Backport of kernel commit https://github.com/torvalds/linux/commit/a8e846b8d93de748485653dd8a6a8efd8f5d7613 .

This is not part of the sources provided by realtek (so far), but this is such low-hanging fruit that it seems to be worth it. I've successfully tested PTP software sync over an RTL8156 with this patch and everything seems to be working properly.

The referenced function was added in kernel 3.5: https://github.com/torvalds/linux/commit/02eacbd0c405d378d2357e8e0fac5de981bd40f8 . In kernel 6.11, there was a slight change of the signature of this function https://github.com/torvalds/linux/commit/2111375b85ad173d58e7b8604246a3de60950ac8#diff-e3cd10bea3926fa6043aacc571413c5a0655a5b300354639f22b5a8aef7bb13aR1201 , but here we use just its name/address and the signature is not relevant.